### PR TITLE
Merges are more robust

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.bigml</groupId>
   <artifactId>histogram</artifactId>
   <packaging>jar</packaging>
-  <version>1.5.0</version>
+  <version>1.5.1</version>
   <name>histogram</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/main/java/com/bigml/histogram/Bin.java
+++ b/src/main/java/com/bigml/histogram/Bin.java
@@ -10,6 +10,10 @@ public class Bin<T extends Target> {
     _count = count;
     _target = target;
   }
+  
+  public Bin(Bin<T> bin) {
+    this(bin.getMean(), bin.getCount(), (T) bin.getTarget().clone());
+  }
 
   public JSONArray toJSON(DecimalFormat format) {
     JSONArray binJSON = new JSONArray();

--- a/src/main/java/com/bigml/histogram/Histogram.java
+++ b/src/main/java/com/bigml/histogram/Histogram.java
@@ -263,7 +263,7 @@ public class Histogram<T extends Target> {
   public void mergeHistogram(Histogram<T> histogram) throws MixedInsertException {
     checkType(histogram.getTargetType());
     for (Bin<T> bin : histogram.getBins()) {
-      insertBin(bin);
+      insertBin(new Bin<T>(bin));
     }
     mergeBins();
   }
@@ -315,7 +315,7 @@ public class Histogram<T extends Target> {
   }
 
   private void checkType(TargetType newType) throws MixedInsertException {
-    if (_targetType == null && newType != null) {
+    if (_targetType == null) {
       _targetType = newType;
     } else if (_targetType != newType || newType == null) {
       throw new MixedInsertException();

--- a/src/main/java/com/bigml/histogram/MixedInsertException.java
+++ b/src/main/java/com/bigml/histogram/MixedInsertException.java
@@ -3,6 +3,6 @@ package com.bigml.histogram;
 public class MixedInsertException extends Exception {
 
   public MixedInsertException() {
-    super("Can't mix insert types (two value bins and three value bins)");
+    super("Can't mix insert types");
   }
 }

--- a/src/test/java/com/bigml/histogram/HistogramTest.java
+++ b/src/test/java/com/bigml/histogram/HistogramTest.java
@@ -60,6 +60,10 @@ public class HistogramTest {
 
     double lessThanZeroSum = hist1.sum(0);
     Assert.assertTrue((lessThanZeroSum > 149000 && lessThanZeroSum < 151000));
+    
+    Histogram emptyHist = new Histogram(10);
+    emptyHist.mergeHistogram(new Histogram(10));
+    Assert.assertTrue(emptyHist.getBins().isEmpty());
   }
   
   @Test


### PR DESCRIPTION
- Fixes issue when merging two empty histograms
- Bins are cloned when merging so the state of the 'merged' histogram does not change
