### PR TITLE
Adds variance, mean, pdf/cdf, and 'flexible' hist edges

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject histogram "1.9.4"
+(defproject histogram "1.9.5"
   :description "Dynamic/streaming histograms"
   :source-path "src/clj"
   :java-source-path "src/java"

--- a/test/histogram/test/core.clj
+++ b/test/histogram/test/core.clj
@@ -32,11 +32,13 @@
                 (/ points 2)
                 (/ points 50)))))
 
-(deftest median-test
+(deftest median-mean-test
   (let [points 10000]
     (is (about= (median (reduce insert! (create) (rand-data points)))
                 0.5 0.05))
     (is (about= (median (reduce insert! (create) (normal-data points)))
+                0 0.05))
+    (is (about= (mean (reduce insert! (create) (normal-data points)))
                 0 0.05))))
 
 (deftest mean-test
@@ -258,3 +260,7 @@
     (is (= (missing-bin hist1) (missing-bin hist2)))
     (is (= (minimum hist1) (minimum hist2)))
     (is (= (maximum hist1) (maximum hist2)))))
+
+(deftest variance-test
+  (is (about= (variance (reduce insert! (create) (normal-data 10000)))
+              1 0.05)))

--- a/test/histogram/test/examples.clj
+++ b/test/histogram/test/examples.clj
@@ -7,71 +7,55 @@
 ;; 100K samples from a normal distribution (mean 0 and variance 1)
 (def normal-data (repeatedly 100000 #(dst/draw (dst/normal-distribution))))
 
-(defn multi-density-chart [hists]
-  (let [bounds (hst/bounds (first hists) true)]
+(defn multi-pdf-chart [hists]
+  (let [min (reduce min (map (comp :min hst/bounds) hists))
+        max (reduce max (map (comp :max hst/bounds) hists))]
     (core/view
      (reduce (fn [c h]
-               (charts/add-function c #(hst/density h %)
-                                    (:min bounds)
-                                    (:max bounds)))
-             (charts/function-plot #(hst/density (first hists) %)
-                                   (:min bounds)
-                                   (:max bounds))
+               (charts/add-function c (hst/pdf h) min max))
+             (charts/function-plot (hst/pdf (first hists)) min max)
              (next hists)))))
 
 (defn sum-density-chart [hist]
-  (let [bounds (hst/bounds hist)]
-    (core/view
-     (-> (charts/function-plot #(hst/sum hist %)
-                               (:min bounds)
-                               (:max bounds))
-         (charts/add-function #(hst/density hist %)
-                              (:min bounds)
-                              (:max bounds))))))
+  (let [{:keys [min max]} (hst/bounds hist true)]
+    (core/view (-> (charts/function-plot #(hst/sum hist %) min max)
+                   (charts/add-function #(hst/density hist %) min max)))))
 
-(defn extended-sum-chart [hist]
-  (let [bounds (hst/bounds hist)]
-    (core/view
-     (-> (charts/function-plot #(:sum (hst/extended-sum hist %))
-                               (:min bounds)
-                               (:max bounds))
-         (charts/add-function #(:sum (:target (hst/extended-sum hist %)))
-                              (:min bounds)
-                              (:max bounds))))))
+(defn cdf-pdf-chart [hist]
+  (let [{:keys [min max]} (hst/bounds hist true)]
+    (core/view (-> (charts/function-plot (hst/cdf hist) min max)
+                   (charts/add-function (hst/pdf hist) min max)))))
 
-(defn density-target-chart [hist]
-  (let [bounds (hst/bounds hist)]
+(defn pdf-target-chart [hist]
+  (let [{:keys [min max]} (hst/bounds hist true)]
     (core/view
-     (-> (charts/function-plot #(hst/density hist %)
-                               (:min bounds)
-                               (:max bounds))
-         (charts/add-function #(:sum (hst/average-target hist %))
-                              (:min bounds)
-                              (:max bounds))))))
+     (-> (charts/function-plot (hst/pdf hist) min max)
+         (charts/add-function #(:sum (hst/average-target hist %)) min max)))))
 
 ;; Builds and charts a histogram for the normal distribution.
 (defn- normal-example []
   (let [hist (reduce hst/insert! (hst/create) normal-data)]
     (println "Total sum of points less than 0:" (hst/sum hist 0))
     (println "Quartile splits:" (hst/uniform hist 4))
-    (sum-density-chart hist)))
+    (sum-density-chart hist)
+    (cdf-pdf-chart hist)))
 
 (defn- varying-bins-example []
-  (multi-density-chart
+  (multi-pdf-chart
    [(reduce hst/insert! (hst/create :bins 16) normal-data)
     (reduce hst/insert! (hst/create :bins 64) normal-data)]))
 
 (defn- gap-weighted-example []
-  (multi-density-chart
+  (multi-pdf-chart
    [(reduce hst/insert! (hst/create :bins 16 :gap-weighted? true) normal-data)
     (reduce hst/insert! (hst/create :bins 16 :gap-weighted? false) normal-data)]))
 
 (defn- numeric-target-example []
-  (let [target-data (map (fn [x] [x (+ 10000 (* 10000 (Math/sin x)))])
+  (let [target-data (map (fn [x] [x (Math/sin x)])
                          normal-data)
         hist (reduce #(apply hst/insert! %1 %2)
                      (hst/create) target-data)]
-    (density-target-chart hist)))
+    (pdf-target-chart hist)))
 
 (defn -main [& args]
   (normal-example)


### PR DESCRIPTION
This PR mainly adds a `variance` method.  `variance` will be useful for better split selection when growing regression trees.  The PR also includes a few other goodies:
- A `mean` fn.
- `cdf` and `pdf`, which return the cumulative distribution function and the probability density function (as Clojure functions) for a histogram.
- Changes the Java histogram `sum` method so that queries on the edges of the histogram will return sum estimates rather than a SumOutOfRangeException.  This enables the `cdf` fn.
