### PR TITLE
Fixes issue when inserting negative zero

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject histogram "1.9.5"
+(defproject histogram "1.9.6"
   :description "Dynamic/streaming histograms"
   :source-path "src/clj"
   :java-source-path "src/java"

--- a/src/java/com/bigml/histogram/Bin.java
+++ b/src/java/com/bigml/histogram/Bin.java
@@ -4,13 +4,18 @@ import java.text.DecimalFormat;
 import org.json.simple.JSONArray;
 
 public class Bin<T extends Target> {
-    
+
   public Bin(double mean, double count, T target) {
-    _mean = mean;
+    /* Hack to avoid Java's negative zero */
+    if (mean == 0d) {
+      _mean = 0d;
+    } else {
+      _mean = mean;
+    }
     _count = count;
     _target = target;
   }
-  
+
   public Bin(Bin<T> bin) {
     this(bin.getMean(), bin.getCount(), (T) bin.getTarget().clone());
   }
@@ -30,7 +35,7 @@ public class Bin<T extends Target> {
   public double getMean() {
     return _mean;
   }
-    
+
   public double getWeight() {
     return _mean * (double) _count;
   }
@@ -43,7 +48,7 @@ public class Bin<T extends Target> {
     if (_mean != bin.getMean()) {
       throw new BinUpdateException("Bins must have matching means to update");
     }
-    
+
     _count += bin.getCount();
     _target.sum(bin.getTarget());
   }
@@ -52,7 +57,7 @@ public class Bin<T extends Target> {
     if (_mean != bin.getMean()) {
       throw new BinUpdateException("Bins must have matching means to update");
     }
-    
+
     _count = bin.getCount();
     _target = (T) bin.getTarget();
   }
@@ -61,7 +66,7 @@ public class Bin<T extends Target> {
   public String toString() {
     return toJSON(new DecimalFormat(Histogram.DEFAULT_FORMAT_STRING)).toJSONString();
   }
-  
+
   public Bin combine(Bin<T> bin) {
     double count = getCount() + bin.getCount();
     double mean = (getWeight() + bin.getWeight()) / (double) count;

--- a/test/histogram/test/core.clj
+++ b/test/histogram/test/core.clj
@@ -264,3 +264,6 @@
 (deftest variance-test
   (is (about= (variance (reduce insert! (create) (normal-data 10000)))
               1 0.05)))
+
+(deftest negative-zero-test
+  (is (= 1 (count (bins (reduce insert! (create) [0.0 -0.0]))))))


### PR DESCRIPTION
The hashcodes differ for Doubles representing 0.0 and -0.0, even though 0.0 == -0.0.  That's bad.  This commit ensures that -0.0 is coerced into 0.0 when adding -0.0 to a histogram.

Issue #22
