### PR TITLE
Adds sum-of-squares to histograms with numeric targets

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject histogram "1.9.9"
+(defproject histogram "2.0.0"
   :description "Dynamic/streaming histograms"
   :source-path "src/clj"
   :java-source-path "src/java"

--- a/src/clj/histogram/core.clj
+++ b/src/clj/histogram/core.clj
@@ -140,7 +140,8 @@
   nil)
 
 (defmethod scrub-target NumericTarget [^NumericTarget target]
-  {:sum (.getTarget target)
+  {:sum (.getSum target)
+   :sum-squares (.getSumSquares target)
    :missing-count (.getMissingCount target)})
 
 (defmethod scrub-target MapCategoricalTarget [^MapCategoricalTarget target]

--- a/src/java/com/bigml/histogram/Histogram.java
+++ b/src/java/com/bigml/histogram/Histogram.java
@@ -349,7 +349,7 @@ public class Histogram<T extends Target> {
 
       NumericTarget countTarget = (NumericTarget) computeSum(bpRatio, new NumericTarget(prevCount),
               new NumericTarget(bin_i.getCount()), new NumericTarget(bin_i1.getCount()));
-      double countSum = countTarget.getTarget();
+      double countSum = countTarget.getSum();
 
       T targetSum = (T) computeSum(bpRatio, prevTargetSum, bin_i.getTarget(), bin_i1.getTarget());
 

--- a/src/java/com/bigml/histogram/MapCategoricalTarget.java
+++ b/src/java/com/bigml/histogram/MapCategoricalTarget.java
@@ -10,26 +10,26 @@ import org.json.simple.JSONObject;
 public class MapCategoricalTarget extends Target<MapCategoricalTarget> implements CategoricalTarget {
 
   public MapCategoricalTarget(Object category) {
-    _target = new HashMap<Object, Double>(1,1);
-    _target.put(category, 1d);
+    _counts = new HashMap<Object, Double>(1,1);
+    _counts.put(category, 1d);
   }
   
   public MapCategoricalTarget(HashMap<Object, Double> targetCounts, double missingCount) {
-    _target = targetCounts;
-    _target.put(null, missingCount);
+    _counts = targetCounts;
+    _counts.put(null, missingCount);
   }
 
   public MapCategoricalTarget(HashMap<Object, Double> targetCounts) {
-    _target = targetCounts;
+    _counts = targetCounts;
   }
   
   public HashMap<Object, Double> getCounts() {
-    return _target;
+    return _counts;
   }
 
   @Override
   public double getMissingCount() {
-    Double missingCount = _target.get(null);
+    Double missingCount = _counts.get(null);
     return missingCount == null ? 0 : missingCount;
   }
   
@@ -41,7 +41,7 @@ public class MapCategoricalTarget extends Target<MapCategoricalTarget> implement
   @Override
   protected void addJSON(JSONArray binJSON, DecimalFormat format) {
     JSONObject counts = new JSONObject();
-    for (Entry<Object,Double> categoryCount : _target.entrySet()) {
+    for (Entry<Object,Double> categoryCount : _counts.entrySet()) {
       Object category = categoryCount.getKey();
       double count = categoryCount.getValue();
       counts.put(category, Double.valueOf(format.format(count)));
@@ -54,11 +54,11 @@ public class MapCategoricalTarget extends Target<MapCategoricalTarget> implement
     for (Entry<Object, Double> categoryCount : target.getCounts().entrySet()) {
       Object category = categoryCount.getKey();
       
-      Double oldCount = _target.get(category);
+      Double oldCount = _counts.get(category);
       oldCount = (oldCount == null) ? 0 : oldCount;
 
       double newCount = oldCount + categoryCount.getValue();
-      _target.put(category, newCount);
+      _counts.put(category, newCount);
     }
     
     return this;
@@ -75,7 +75,7 @@ public class MapCategoricalTarget extends Target<MapCategoricalTarget> implement
 
   @Override
   protected MapCategoricalTarget clone() {
-    return new MapCategoricalTarget(new HashMap<Object, Double>(_target));
+    return new MapCategoricalTarget(new HashMap<Object, Double>(_counts));
   }
 
   @Override
@@ -83,5 +83,5 @@ public class MapCategoricalTarget extends Target<MapCategoricalTarget> implement
     return new MapCategoricalTarget(new HashMap<Object, Double>());
   }
   
-  private HashMap<Object, Double> _target;
+  private HashMap<Object, Double> _counts;
 }

--- a/src/java/com/bigml/histogram/NumericTarget.java
+++ b/src/java/com/bigml/histogram/NumericTarget.java
@@ -6,8 +6,17 @@ import org.json.simple.JSONArray;
 
 public class NumericTarget extends Target<NumericTarget> {
   
+  private NumericTarget(Double target, Double sumSquares, double missingCount) {
+    _sum = target;
+    _sumSquares = sumSquares;
+    _missingCount = missingCount;
+  }
+
   public NumericTarget(Double target, double missingCount) {
-    _target = target;
+    _sum = target;
+    if (target != null) {
+      _sumSquares = target * target;
+    }
     _missingCount = missingCount;
   }
   
@@ -15,10 +24,14 @@ public class NumericTarget extends Target<NumericTarget> {
     this(target, target == null ? 1 : 0);
   }
 
-  public Double getTarget() {
-    return _target;
+  public Double getSum() {
+    return _sum;
   }
-  
+
+  public Double getSumSquares() {
+    return _sumSquares;
+  }
+
   @Override
   public double getMissingCount() {
     return _missingCount;
@@ -31,15 +44,16 @@ public class NumericTarget extends Target<NumericTarget> {
   
   @Override
   public String toString() {
-    return String.valueOf(_target);
+    return String.valueOf(_sum) + "," + String.valueOf(_sumSquares);
   }
 
   @Override
   protected void addJSON(JSONArray binJSON, DecimalFormat format) {
-    if (_target == null) {
+    if (_sum == null) {
       binJSON.add(null);
     } else {
-      binJSON.add(Double.valueOf(format.format(_target)));
+      binJSON.add(Double.valueOf(format.format(_sum)));
+      binJSON.add(Double.valueOf(format.format(_sumSquares)));
     }
   }
   
@@ -50,18 +64,21 @@ public class NumericTarget extends Target<NumericTarget> {
 
   @Override
   protected NumericTarget clone() {
-    return new NumericTarget(_target, _missingCount);
+    return new NumericTarget(_sum, _sumSquares, _missingCount);
   }
 
-  private Double _target;
+  private Double _sum;
+  private Double _sumSquares;
   private double _missingCount;
 
   @Override
   protected NumericTarget sum(NumericTarget target) {
-    if (_target == null && target.getTarget() != null) {
-      _target = target.getTarget();
-    } else if (_target != null && target.getTarget() != null){
-      this._target += target.getTarget();
+    if (_sum == null && target.getSum() != null) {
+      _sum = target.getSum();
+      _sumSquares = target.getSumSquares();
+    } else if (_sum != null && target.getSum() != null){
+      _sum += target.getSum();
+      _sumSquares += target.getSumSquares();
     }
     _missingCount += target.getMissingCount();
     return this;
@@ -69,8 +86,9 @@ public class NumericTarget extends Target<NumericTarget> {
   
   @Override
   protected NumericTarget mult(double multiplier) {
-    if (_target != null) {
-      _target *= multiplier;
+    if (_sum != null) {
+      _sum *= multiplier;
+      _sumSquares *= multiplier;
     }
     _missingCount *= multiplier;
     return this;


### PR DESCRIPTION
This PR adds the sum of squares as another measure tracked by histograms with numeric targets.  This allows us to compute the variance for numeric targets (useful for upcoming wintermute improvements).
