### PR TITLE
Little transformation fixes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject histogram "2.0.0"
+(defproject histogram "2.0.1"
   :description "Dynamic/streaming histograms"
   :source-path "src/clj"
   :java-source-path "src/java"

--- a/src/java/com/bigml/histogram/NumericTarget.java
+++ b/src/java/com/bigml/histogram/NumericTarget.java
@@ -5,8 +5,8 @@ import java.text.DecimalFormat;
 import org.json.simple.JSONArray;
 
 public class NumericTarget extends Target<NumericTarget> {
-  
-  private NumericTarget(Double target, Double sumSquares, double missingCount) {
+
+  public NumericTarget(Double target, Double sumSquares, double missingCount) {
     _sum = target;
     _sumSquares = sumSquares;
     _missingCount = missingCount;
@@ -19,7 +19,7 @@ public class NumericTarget extends Target<NumericTarget> {
     }
     _missingCount = missingCount;
   }
-  
+
   public NumericTarget(Double target) {
     this(target, target == null ? 1 : 0);
   }
@@ -41,7 +41,7 @@ public class NumericTarget extends Target<NumericTarget> {
   public TargetType getTargetType() {
     return Histogram.TargetType.numeric;
   }
-  
+
   @Override
   public String toString() {
     return String.valueOf(_sum) + "," + String.valueOf(_sumSquares);
@@ -56,7 +56,7 @@ public class NumericTarget extends Target<NumericTarget> {
       binJSON.add(Double.valueOf(format.format(_sumSquares)));
     }
   }
-  
+
   @Override
   protected NumericTarget init() {
     return new NumericTarget(0d);
@@ -83,7 +83,7 @@ public class NumericTarget extends Target<NumericTarget> {
     _missingCount += target.getMissingCount();
     return this;
   }
-  
+
   @Override
   protected NumericTarget mult(double multiplier) {
     if (_sum != null) {

--- a/test/histogram/test/core.clj
+++ b/test/histogram/test/core.clj
@@ -256,6 +256,12 @@
     (is (== 5 (maximum merged)))))
 
 (deftest transform-test
+  (let [hist (-> (create)
+                 (insert! 1 [2 3 :a])
+                 (insert! 1 [9 2 :b])
+                 (insert! 4 [5 nil nil]))]
+    (is (= (hist-to-clj hist)
+           (hist-to-clj (clj-to-hist (hist-to-clj hist))))))
   (let [hist1 (reduce (fn [h [x y]] (insert! h x y))
                       (create :bins 8 :gap-weighted? true
                               :categories [:apple :orange :grape])


### PR DESCRIPTION
Fixes the transformation from Clojure to Java for the sum of squares (in numeric targets) and fixes transformations for group targets.

Bumps version to 2.0.1
