### PR TITLE
Small fixes for density estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ interface, but Java developers can find documented methods in
 For [Leiningen](https://github.com/technomancy/leiningen):
 
 ```clojure
-[bigml/histogram "3.0.1"]
+[bigml/histogram "3.0.2"]
 ```
 
 For [Maven](http://maven.apache.org/):
@@ -38,7 +38,7 @@ For [Maven](http://maven.apache.org/):
 <dependency>
   <groupId>bigml</groupId>
   <artifactId>histogram</artifactId>
-  <version>3.0.1</version>
+  <version>3.0.2</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 
-(defproject bigml/histogram "3.0.1"
+(defproject bigml/histogram "3.0.2"
   :description "Streaming histograms for Clojure/Java"
   :min-lein-version "2.0.0"
   :url "https://github.com/bigmlcom/histogram"

--- a/src/java/com/bigml/histogram/Histogram.java
+++ b/src/java/com/bigml/histogram/Histogram.java
@@ -389,9 +389,12 @@ public class Histogram<T extends Target> {
     if (p < _minimum || p > _maximum) {
       countDensity = 0;
       targetDensity = (T) emptyTarget.clone();
+    } else if (p == _minimum && p == _maximum) {
+      countDensity = Double.POSITIVE_INFINITY;
+      targetDensity = emptyTarget;
     } else if (exact != null) {
-      double higher = Double.longBitsToDouble(Double.doubleToLongBits(p) + 1);
-      double lower = Double.longBitsToDouble(Double.doubleToLongBits(p) - 1);
+      double higher = Math.nextAfter(p, Double.POSITIVE_INFINITY);
+      double lower = Math.nextAfter(p, Double.NEGATIVE_INFINITY);
 
       SumResult<T> lowerResult = extendedDensity(lower);
       SumResult<T> higherResult = extendedDensity(higher);

--- a/test/bigml/histogram/test/core.clj
+++ b/test/bigml/histogram/test/core.clj
@@ -315,3 +315,11 @@
   (is (thrown? SumOutOfRangeException (sum (create) 5)))
   (is (thrown? SumOutOfRangeException
                (sum (insert! (create) 4) Double/NaN))))
+
+(deftest point-density-at-zero
+  (is (== 1 (-> (reduce insert! (create) [-1 0 1])
+                (density 0))))
+  (is (= Double/POSITIVE_INFINITY
+         (-> (create)
+             (insert! 0)
+             (density 0)))))


### PR DESCRIPTION
Querying for the density at a bin centered at zero no longer returns `NaN`.  For histograms that have only seen one value, querying the density at that point will return `Infinity`.  This, I believe, is the correct result for a histogram whose CDF is essentially a step function.

``` clojure
(-> (create)
    (insert! 0)
    (density 0))
;; Infinity
```

Issue #38
