### PR TITLE
Bumps incanter to 1.4.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
   :javac-options ["-target" "1.6" "-source" "1.6"]
-  :profiles {:dev {:dependencies [[incanter/incanter-core "1.3.0"]
-                                  [incanter/incanter-charts "1.3.0"]]}}
+  :profiles {:dev {:dependencies [[incanter/incanter-core "1.4.1"]
+                                  [incanter/incanter-charts "1.4.1"]]}}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [com.googlecode.json-simple/json-simple "1.1"]])


### PR DESCRIPTION
This version of incanter is more friendly to Clojure 1.5, so the charting examples now work again.
