### PR TITLE
Add appendTo(Appendable) and appendTo(Appendable, DecimalFormat) methods for non-JSON output

### DIFF
--- a/src/java/com/bigml/histogram/ArrayCategoricalTarget.java
+++ b/src/java/com/bigml/histogram/ArrayCategoricalTarget.java
@@ -6,6 +6,7 @@
 package com.bigml.histogram;
 
 import com.bigml.histogram.Histogram.TargetType;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -70,6 +71,24 @@ public class ArrayCategoricalTarget extends Target<ArrayCategoricalTarget> imple
       counts.put(category, Utils.roundNumber(count, format));
     }
     binJSON.add(counts);
+  }
+
+  @Override
+  protected void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    for (Entry<Object,Integer> categoryIndex : _indexMap.entrySet()) {
+      Object category = categoryIndex.getKey();
+      int index = categoryIndex.getValue();
+      double count = _target[index];
+      appendable.append(String.valueOf(category));
+      appendable.append("\t");
+      appendable.append(format.format(count));
+    }
   }
 
   @Override

--- a/src/java/com/bigml/histogram/Bin.java
+++ b/src/java/com/bigml/histogram/Bin.java
@@ -5,6 +5,7 @@
  */
 package com.bigml.histogram;
 
+import java.io.IOException;
 import java.text.DecimalFormat;
 import org.json.simple.JSONArray;
 
@@ -66,6 +67,28 @@ public class Bin<T extends Target> implements Comparable<Bin> {
   @Override
   public String toString() {
     return toJSON(new DecimalFormat(Histogram.DEFAULT_FORMAT_STRING)).toJSONString();
+  }
+
+  /**
+   * Append a text representation of this bin to the specified appendable.
+   *
+   * @param appendable appendable to append to, must not be null
+   * @param format decimal format, must not be null
+   * @throws IOException if an error occurs
+   */
+  public void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    appendable.append(format.format(_mean));
+    appendable.append("\t");
+    appendable.append(format.format(_count));
+    appendable.append("\t");
+    _target.appendTo(appendable, format);
+    appendable.append("\n");
   }
 
   public Bin combine(Bin<T> bin) {

--- a/src/java/com/bigml/histogram/GroupTarget.java
+++ b/src/java/com/bigml/histogram/GroupTarget.java
@@ -6,6 +6,7 @@
 package com.bigml.histogram;
 
 import com.bigml.histogram.Histogram.TargetType;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -73,6 +74,20 @@ public class GroupTarget extends Target<GroupTarget> {
       target.addJSON(targetsJSON, format);
     }
     binJSON.add(targetsJSON);
+  }
+
+  @Override
+  protected void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    for (Target target : _target) {
+      target.appendTo(appendable, format);
+      appendable.append("\t");
+    }
   }
   
   @Override

--- a/src/java/com/bigml/histogram/Histogram.java
+++ b/src/java/com/bigml/histogram/Histogram.java
@@ -5,6 +5,7 @@
  */
 package com.bigml.histogram;
 
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -569,6 +570,35 @@ public class Histogram<T extends Target> {
   @Override
   public String toString() {
     return toJSONString(_decimalFormat);
+  }
+
+  /**
+   * Append a text representation of this histogram to the specified appendable.
+   *
+   * @param appendable appendable to append to, must not be null
+   * @throws IOException if an error occurs
+   */
+  public void appendTo(final Appendable appendable) throws IOException {
+    appendTo(appendable, _decimalFormat);
+  }
+
+  /**
+   * Append a text representation of this histogram to the specified appendable.
+   *
+   * @param appendable appendable to append to, must not be null
+   * @param format decimal format, must not be null
+   * @throws IOException if an error occurs
+   */
+  public void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    for (Bin<T> bin : getBins()) {
+      bin.appendTo(appendable, format);
+    }
   }
 
   /*

--- a/src/java/com/bigml/histogram/MapCategoricalTarget.java
+++ b/src/java/com/bigml/histogram/MapCategoricalTarget.java
@@ -6,6 +6,7 @@
 package com.bigml.histogram;
 
 import com.bigml.histogram.Histogram.TargetType;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map.Entry;
@@ -52,6 +53,23 @@ public class MapCategoricalTarget extends Target<MapCategoricalTarget> implement
       counts.put(category, Utils.roundNumber(count, format));
     }
     binJSON.add(counts);
+  }
+
+  @Override
+  protected void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    for (Entry<Object,Double> categoryCount : _counts.entrySet()) {
+      Object category = categoryCount.getKey();
+      double count = categoryCount.getValue();
+      appendable.append(String.valueOf(category));
+      appendable.append("\t");
+      appendable.append(format.format(count));
+    }
   }
 
   @Override

--- a/src/java/com/bigml/histogram/NumericTarget.java
+++ b/src/java/com/bigml/histogram/NumericTarget.java
@@ -6,6 +6,7 @@
 package com.bigml.histogram;
 
 import com.bigml.histogram.Histogram.TargetType;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import org.json.simple.JSONArray;
 
@@ -59,6 +60,21 @@ public class NumericTarget extends Target<NumericTarget> {
     } else {
       binJSON.add(Utils.roundNumber(_sum, format));
       binJSON.add(Utils.roundNumber(_sumSquares, format));
+    }
+  }
+
+  @Override
+  protected void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    if (_sum != null) {
+      appendable.append(format.format(_sum));
+      appendable.append("\t");
+      appendable.append(format.format(_sumSquares));
     }
   }
 

--- a/src/java/com/bigml/histogram/SimpleTarget.java
+++ b/src/java/com/bigml/histogram/SimpleTarget.java
@@ -6,6 +6,7 @@
 package com.bigml.histogram;
 
 import com.bigml.histogram.Histogram.TargetType;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import org.json.simple.JSONArray;
 
@@ -25,6 +26,18 @@ public class SimpleTarget extends Target<SimpleTarget> {
 
   @Override
   protected void addJSON(JSONArray binJSON, DecimalFormat format) {
+      // empty
+  }
+
+  @Override
+  protected void appendTo(final Appendable appendable, final DecimalFormat format) throws IOException {
+    if (appendable == null) {
+      throw new NullPointerException("appendable must not be null");
+    }
+    if (format == null) {
+      throw new NullPointerException("format must not be null");
+    }
+    // empty
   }
   
   @Override

--- a/src/java/com/bigml/histogram/Target.java
+++ b/src/java/com/bigml/histogram/Target.java
@@ -6,6 +6,7 @@
 package com.bigml.histogram;
 
 import com.bigml.histogram.Histogram.TargetType;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import org.json.simple.JSONArray;
 
@@ -15,6 +16,7 @@ public abstract class Target<T extends Target> {
   public abstract TargetType getTargetType();
   
   protected abstract void addJSON(JSONArray binJSON, DecimalFormat format);
+  protected abstract void appendTo(Appendable appendable, DecimalFormat format) throws IOException;
   protected abstract T sum(T target);
   protected abstract T mult(double multiplier);
 


### PR DESCRIPTION
It seemed odd to me that Histogram.toString() returns JSON-formatted output, so I have added appendTo(Appendable) and appendTo(Appendable, DecimalFormat) methods where necessary to write tab-delimited text.
