### PR TITLE
Fix: median returns nil for empty histograms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .#*
-pom.xml
+pom.xml*
 *jar
 /lib/
 /classes/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For [Maven](http://maven.apache.org/):
 <dependency>
   <groupId>bigml</groupId>
   <artifactId>histogram</artifactId>
-  <version>4.1.0</version>
+  <version>4.1.1</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 
-(defproject bigml/histogram "4.1.0"
+(defproject bigml/histogram "4.1.1"
   :description "Streaming histograms for Clojure/Java"
   :min-lein-version "2.0.0"
   :url "https://github.com/bigmlcom/histogram"

--- a/src/clj/bigml/histogram/core.clj
+++ b/src/clj/bigml/histogram/core.clj
@@ -329,23 +329,24 @@
    will be the true median whenever the histogram has less than the
    maximum number of bins, otherwise it will be an approximation."
   [hist]
-  (if (= (bin-count hist) (max-bins hist))
-    ;; Return the approximate median
-    (first (uniform hist 2))
-    ;; Return the exact median when possible
-    (let [bns (bins hist)
-          pop (int (total-count hist))
-          mid-index (int (/ pop 2))]
-      (loop [pval (:mean (first bns))
-             tot 0
-             bns bns]
-        (let [{:keys [mean count]} (first bns)
-              ntot (long (+ tot count))]
-          (cond (and (odd? pop) (>= ntot (inc mid-index))) mean
-                (and (even? pop) (= (inc tot) (inc mid-index)))
-                (/ (+ pval mean) 2)
-                (> ntot mid-index) mean
-                :else (recur mean ntot (next bns))))))))
+  (when (pos? (total-count hist))
+    (if (= (bin-count hist) (max-bins hist))
+      ;; Return the approximate median
+      (first (uniform hist 2))
+      ;; Return the exact median when possible
+      (let [bns (bins hist)
+            pop (int (total-count hist))
+            mid-index (int (/ pop 2))]
+        (loop [pval (:mean (first bns))
+               tot 0
+               bns bns]
+          (let [{:keys [mean count]} (first bns)
+                ntot (long (+ tot count))]
+            (cond (and (odd? pop) (>= ntot (inc mid-index))) mean
+                  (and (even? pop) (= (inc tot) (inc mid-index)))
+                  (/ (+ pval mean) 2)
+                  (> ntot mid-index) mean
+                  :else (recur mean ntot (next bns)))))))))
 
 (defn cdf
   "Returns the cumulative distribution function for the histogram."

--- a/test/bigml/histogram/test/core.clj
+++ b/test/bigml/histogram/test/core.clj
@@ -361,6 +361,9 @@
 (deftest nil-target-sum
   (is (nil? (total-target-sum (create)))))
 
+(deftest nil-median
+  (is (nil? (median (create)))))
+
 (deftest sum-edges
   (let [hist (reduce insert! (create) [0 10])]
     (is (== 1 (sum hist 5)))


### PR DESCRIPTION
Bumps to version `4.1.1`.