### PR TITLE
target java 1.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
+  :javac-options ["-source" "1.6" "-target" "1.6"]
   :aliases {"lint" ["do" "check," "eastwood"]
             "distcheck" ["do" "clean," "lint," "test"]}
   :profiles {:dev {:plugins [[jonase/eastwood "0.1.4"]]


### PR DESCRIPTION
Howdy,

We (sadly) have some servers still running java 1.6. The current release jar is compiled against 1.7 and thus java complains about an `UnsupportedVersion`. This fixes that. There are not 1.7 only features in the code base, so there is no harm that I can see in adding this. 