### PR TITLE
Fixes median calc for large populations - bumps to v4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For [Maven](http://maven.apache.org/):
 <dependency>
   <groupId>bigml</groupId>
   <artifactId>histogram</artifactId>
-  <version>4.1.1</version>
+  <version>4.1.2</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 
-(defproject bigml/histogram "4.1.1"
+(defproject bigml/histogram "4.1.2"
   :description "Streaming histograms for Clojure/Java"
   :min-lein-version "2.0.0"
   :url "https://github.com/bigmlcom/histogram"

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
+  :javac-options ["-source" "1.6" "-target" "1.6"]
   :aliases {"lint" ["do" "check," "eastwood"]
             "distcheck" ["do" "clean," "lint," "test"]}
   :profiles {:dev {:plugins [[jonase/eastwood "0.1.4"]]

--- a/src/clj/bigml/histogram/core.clj
+++ b/src/clj/bigml/histogram/core.clj
@@ -335,8 +335,8 @@
       (first (uniform hist 2))
       ;; Return the exact median when possible
       (let [bns (bins hist)
-            pop (int (total-count hist))
-            mid-index (int (/ pop 2))]
+            pop (long (total-count hist))
+            mid-index (long (/ pop 2))]
         (loop [pval (:mean (first bns))
                tot 0
                bns bns]

--- a/test/bigml/histogram/test/core.clj
+++ b/test/bigml/histogram/test/core.clj
@@ -364,6 +364,16 @@
 (deftest nil-median
   (is (nil? (median (create)))))
 
+(deftest big-median
+  (is (== (-> (create :bins 6)
+              (insert-bin! {:mean 0 :count 1E10})
+              (insert-bin! {:mean 1 :count 1E10})
+              (insert-bin! {:mean 2 :count 1E10})
+              (insert-bin! {:mean 5 :count 1E10})
+              (insert-bin! {:mean 9 :count 1E10})
+              (median))
+          2)))
+
 (deftest sum-edges
   (let [hist (reduce insert! (create) [0 10])]
     (is (== 1 (sum hist 5)))


### PR DESCRIPTION
Also includes @sorenmacbeth's commit for targeting Java 1.6.